### PR TITLE
カレンダーに画像が挿入されたときにボタンが表示されないバグ改修

### DIFF
--- a/content.js
+++ b/content.js
@@ -49,6 +49,7 @@ const createSvgContainer = () => {
     cursor: "pointer",
     width: "40px",
     height: "40px",
+    zIndex: "1",
   };
   applyStyles(button, buttonStyles);
   const svgElement = createSvgElement();


### PR DESCRIPTION
一旦これで対応！

<div align="center">

<img src="https://github.com/user-attachments/assets/9fa5e027-0e88-479f-af3a-1c931146d450" width="600px">
</div>
